### PR TITLE
添加 statfs 系统调用

### DIFF
--- a/include/kmod/syscall.h
+++ b/include/kmod/syscall.h
@@ -125,6 +125,7 @@ SysRet<void> sys_vfs_link(CapIdx parent_dir_cap, const char *name, CapIdx target
 SysRet<void> sys_vfs_stat(CapIdx parent_dir_cap, const char *name, NodeMeta *out);
 SysRet<void> sys_vfs_lstat(CapIdx parent_dir_cap, const char *name, NodeMeta *out);
 SysRet<void> sys_vfs_fstat(CapIdx file_cap, NodeMeta *out);
+SysRet<void> sys_vfs_statfs(CapIdx capidx, VFSStatFS *out);
 SysRet<void> sys_vfs_ioctl(CapIdx file_cap, size_t cmd, void *arg, size_t arg_len);
 SysRet<void> sys_vfs_getattr(CapIdx capidx, AttrSet *out);
 SysRet<void> sys_vfs_getattr_at(CapIdx parent_dir_cap, const char *name,

--- a/include/sustcore/files.h
+++ b/include/sustcore/files.h
@@ -87,6 +87,11 @@ struct VFSPageCacheStats {
     size_t backing_writes;
 };
 
+struct VFSStatFS {
+    uint64_t f_type;
+    uint64_t f_blocks;
+};
+
 static_assert(sizeof(dir_entry_header) == sizeof(size_t),
               "dir_entry_header must match next_offset size");
 

--- a/include/sustcore/syscall.h
+++ b/include/sustcore/syscall.h
@@ -94,6 +94,7 @@
 #define SYS_PCB_SIGACTION       (SYSCALL_BASE + 0x4B)
 #define SYS_PCB_SIGNAL          (SYSCALL_BASE + 0x4C)
 #define SYS_PCB_WAITSIG         (SYSCALL_BASE + 0x4D)
+#define SYS_VFS_STATFS          (SYSCALL_BASE + 0x4E)
 
 // 以SYS_UNSTABLE_BASE开头的系统调用为不稳定接口, 可能会在后续版本中更改或移除
 #define SYS_UNSTABLE_BASE        (0xFFC00000)

--- a/kernel/syscall/syscall.cpp
+++ b/kernel/syscall/syscall.cpp
@@ -388,6 +388,7 @@ namespace syscall {
             case SYS_VFS_LSTAT:          return "SYS_VFS_LSTAT";
             case SYS_VFS_READLINK:       return "SYS_VFS_READLINK";
             case SYS_VFS_FSTAT:          return "SYS_VFS_FSTAT";
+            case SYS_VFS_STATFS:         return "SYS_VFS_STATFS";
             case SYS_MNT_CREATE:         return "SYS_MNT_CREATE";
             case SYS_MNT_MOUNT:          return "SYS_MNT_MOUNT";
             case SYS_MNT_UMOUNT:         return "SYS_MNT_UMOUNT";
@@ -894,6 +895,12 @@ namespace syscall {
                 UBuffer buf((VirAddr)arg0, sizeof(NodeMeta));
                 ret = result_void_ret("fstat",
                                       vfs_fstat(capidx, std::move(buf)));
+                break;
+            }
+            case SYS_VFS_STATFS: {
+                UBuffer buf((VirAddr)arg0, sizeof(VFSStatFS));
+                ret = result_void_ret("statfs",
+                                      vfs_statfs(capidx, std::move(buf)));
                 break;
             }
             case SYS_VFS_READLINK: {

--- a/kernel/syscall/vfs.cpp
+++ b/kernel/syscall/vfs.cpp
@@ -341,6 +341,19 @@ namespace syscall {
         return out.commit_to_user(sizeof(st));
     }
 
+    Result<void> vfs_statfs(CapIdx capidx, UBuffer &&out) {
+        if (out.kbuf() == nullptr || out.len() < sizeof(VFSStatFS)) {
+            unexpect_return(ErrCode::INVALID_PARAM);
+        }
+        auto cap_res = lookup_current_cap(capidx);
+        propagate(cap_res);
+        VFSStatFS st{};
+        auto statfs_res = VFS::inst().statfs(*cap_res.value(), st);
+        propagate(statfs_res);
+        memcpy(out.kbuf(), &st, sizeof(st));
+        return out.commit_to_user(sizeof(st));
+    }
+
     Result<void> vfs_getattr(CapIdx capidx, UBuffer &&out) {
         if (out.kbuf() == nullptr || out.len() < sizeof(AttrSet)) {
             unexpect_return(ErrCode::INVALID_PARAM);

--- a/kernel/syscall/vfs.h
+++ b/kernel/syscall/vfs.h
@@ -75,6 +75,8 @@ namespace syscall {
     [[nodiscard]]
     Result<void> vfs_fstat(CapIdx file_cap, UBuffer &&out);
     [[nodiscard]]
+    Result<void> vfs_statfs(CapIdx capidx, UBuffer &&out);
+    [[nodiscard]]
     Result<void> vfs_getattr(CapIdx capidx, UBuffer &&out);
     [[nodiscard]]
     Result<void> vfs_getattr_at(CapIdx parent_dir_cap, const UString &relpath,

--- a/kernel/vfs/vfs.cpp
+++ b/kernel/vfs/vfs.cpp
@@ -52,6 +52,54 @@ namespace {
     static VINode::CachedFilePage *active_head   = nullptr;
     static VINode::CachedFilePage *active_tail   = nullptr;
 
+    constexpr uint64_t EXT4_SUPER_MAGIC  = 0xEF53;
+    constexpr uint64_t TMPFS_MAGIC       = 0x01021994;
+    constexpr uint64_t PROC_SUPER_MAGIC  = 0x9FA0;
+    constexpr uint64_t DEVFS_SUPER_MAGIC = 0x1373;
+    constexpr uint64_t TARFS_SUPER_MAGIC = 0x74617266;
+    constexpr uint64_t PSEUDO_FS_BLOCKS  = 1;
+
+    [[nodiscard]]
+    uint64_t statfs_magic_from_name(const char *name) noexcept {
+        if (name == nullptr) {
+            return 0;
+        }
+        if (strcmp(name, "ext4") == 0) {
+            return EXT4_SUPER_MAGIC;
+        }
+        if (strcmp(name, "tmpfs") == 0) {
+            return TMPFS_MAGIC;
+        }
+        if (strcmp(name, "procfs") == 0) {
+            return PROC_SUPER_MAGIC;
+        }
+        if (strcmp(name, "devfs") == 0) {
+            return DEVFS_SUPER_MAGIC;
+        }
+        if (strcmp(name, "tarfs") == 0) {
+            return TARFS_SUPER_MAGIC;
+        }
+        return 0;
+    }
+
+    [[nodiscard]]
+    bool statfs_is_pseudo_name(const char *name) noexcept {
+        if (name == nullptr) {
+            return false;
+        }
+        return strcmp(name, "tmpfs") == 0 || strcmp(name, "procfs") == 0 ||
+               strcmp(name, "devfs") == 0;
+    }
+
+    void fill_statfs_from_vinode(VINode &vnode, VFSStatFS &out) noexcept {
+        memset(&out, 0, sizeof(out));
+        const char *fs_name = vnode.superblock().sb()->fs().name();
+        out.f_type          = statfs_magic_from_name(fs_name);
+        if (statfs_is_pseudo_name(fs_name)) {
+            out.f_blocks = PSEUDO_FS_BLOCKS;
+        }
+    }
+
     class PageCacheReadGuard {
     public:
         PageCacheReadGuard() {
@@ -2492,6 +2540,33 @@ Result<void> VFS::fstat(cap::Capability &cap, NodeMeta &out) const {
         return _stat_from_vinode(*vdir->vinode().get(), out);
     }
     unexpect_return(ErrCode::TYPE_NOT_MATCHED);
+}
+
+Result<void> VFS::statfs(cap::Capability &cap, VFSStatFS &out) const {
+    if (auto *vfile = cap.payload_as<VFile>(); vfile != nullptr) {
+        fill_statfs_from_vinode(*vfile->vinode().get(), out);
+        void_return();
+    }
+    if (auto *vdir = cap.payload_as<VDirectory>(); vdir != nullptr) {
+        fill_statfs_from_vinode(*vdir->vinode().get(), out);
+        void_return();
+    }
+    unexpect_return(ErrCode::TYPE_NOT_MATCHED);
+}
+
+Result<void> VFS::statfs_at(cap::Capability &parent_dir_cap,
+                            const char *relpath, VFSStatFS &out) const {
+    auto *parent = parent_dir_cap.payload_as<VDirectory>();
+    if (parent == nullptr) {
+        unexpect_return(ErrCode::TYPE_NOT_MATCHED);
+    }
+    auto global_res = _global_target_path(*parent, relpath);
+    propagate(global_res);
+    util::Path mount_path;
+    auto vnode_res = _resolve_inode(global_res.value().second, mount_path);
+    propagate(vnode_res);
+    fill_statfs_from_vinode(*vnode_res.value().get(), out);
+    void_return();
 }
 
 Result<void> VFS::getattr(cap::Capability &cap, AttrSet &out) const {

--- a/kernel/vfs/vfs.h
+++ b/kernel/vfs/vfs.h
@@ -569,6 +569,11 @@ public:
     Result<void> lstat(cap::Capability &parent_dir_cap, const char *relpath,
                        NodeMeta &out) const;
     [[nodiscard]]
+    Result<void> statfs(cap::Capability &cap, VFSStatFS &out) const;
+    [[nodiscard]]
+    Result<void> statfs_at(cap::Capability &parent_dir_cap, const char *relpath,
+                           VFSStatFS &out) const;
+    [[nodiscard]]
     Result<void> getattr(cap::Capability &cap, AttrSet &out) const;
     [[nodiscard]]
     Result<void> getattr_at(cap::Capability &parent_dir_cap,

--- a/libs/kmod/arch/loongarch64/asm_syscall.S
+++ b/libs/kmod/arch/loongarch64/asm_syscall.S
@@ -382,6 +382,12 @@ sys_vfs_fstat:
     li.d $a7, SYS_VFS_FSTAT
     do_syscall
 
+    .global sys_vfs_statfs
+    .type sys_vfs_statfs, @function
+sys_vfs_statfs:
+    li.d $a7, SYS_VFS_STATFS
+    do_syscall
+
     .global sys_vfs_ioctl
     .type sys_vfs_ioctl, @function
 sys_vfs_ioctl:

--- a/libs/kmod/arch/riscv64/asm_syscall.S
+++ b/libs/kmod/arch/riscv64/asm_syscall.S
@@ -446,6 +446,14 @@ sys_vfs_fstat:
     ecall
     ret
 
+    .global sys_vfs_statfs
+    .type sys_vfs_statfs, @function
+sys_vfs_statfs:
+    /* a0 = cap, a1 = VFSStatFS* */
+    li a7, SYS_VFS_STATFS
+    ecall
+    ret
+
     .global sys_vfs_ioctl
     .type sys_vfs_ioctl, @function
 sys_vfs_ioctl:

--- a/libs/linuxss-libc/arch/loongarch64/asm_syscall.S
+++ b/libs/linuxss-libc/arch/loongarch64/asm_syscall.S
@@ -441,6 +441,13 @@ sys_vfs_fstat:
     syscall 0
     ret
 
+    .global sys_vfs_statfs
+    .type sys_vfs_statfs, @function
+sys_vfs_statfs:
+    li.d $a7, SYS_VFS_STATFS
+    syscall 0
+    ret
+
     .global sys_vfs_ioctl
     .type sys_vfs_ioctl, @function
 sys_vfs_ioctl:

--- a/libs/linuxss-libc/arch/riscv64/asm_syscall.S
+++ b/libs/linuxss-libc/arch/riscv64/asm_syscall.S
@@ -440,6 +440,13 @@ sys_vfs_fstat:
     ecall
     ret
 
+    .global sys_vfs_statfs
+    .type   sys_vfs_statfs, @function
+sys_vfs_statfs:
+    li a7, SYS_VFS_STATFS
+    ecall
+    ret
+
     .global sys_vfs_ioctl
     .type   sys_vfs_ioctl, @function
 sys_vfs_ioctl:

--- a/libs/linuxss-libc/syscall.h
+++ b/libs/linuxss-libc/syscall.h
@@ -139,6 +139,7 @@ extern "C" SysRet<void> sys_vfs_stat(CapIdx parent_dir_cap, const char *name,
 extern "C" SysRet<void> sys_vfs_lstat(CapIdx parent_dir_cap, const char *name,
                                       NodeMeta *out);
 extern "C" SysRet<void> sys_vfs_fstat(CapIdx file_cap, NodeMeta *out);
+extern "C" SysRet<void> sys_vfs_statfs(CapIdx capidx, VFSStatFS *out);
 extern "C" SysRet<void> sys_vfs_ioctl(CapIdx file_cap, size_t cmd, void *arg,
                                       size_t arg_len);
 extern "C" SysRet<void> sys_vfs_getattr(CapIdx capidx, AttrSet *out);

--- a/module/linux-subsystem/file.cpp
+++ b/module/linux-subsystem/file.cpp
@@ -133,6 +133,25 @@ namespace {
         unsigned __unused[2];
     };
 
+    struct linux_fsid_t {
+        int val[2];
+    };
+
+    struct linux_statfs {
+        long f_type;
+        long f_bsize;
+        uint64_t f_blocks;
+        uint64_t f_bfree;
+        uint64_t f_bavail;
+        uint64_t f_files;
+        uint64_t f_ffree;
+        linux_fsid_t f_fsid;
+        long f_namelen;
+        long f_frsize;
+        long f_flags;
+        long f_spare[4];
+    };
+
     constexpr uint32_t STATX_TYPE   = 0x0001U;
     constexpr uint32_t STATX_MODE   = 0x0002U;
     constexpr uint32_t STATX_NLINK  = 0x0004U;
@@ -669,6 +688,49 @@ namespace {
         kst.st_atime_sec = static_cast<long>(attrs.atime);
         kst.st_mtime_sec = static_cast<long>(attrs.mtime);
         kst.st_ctime_sec = static_cast<long>(attrs.ctime);
+    }
+
+    void fill_statfs_from_vfs(const VFSStatFS &src, linux_statfs &dst) {
+        memset(&dst, 0, sizeof(dst));
+        dst.f_type   = static_cast<long>(src.f_type);
+        dst.f_bsize  = 4096;
+        dst.f_blocks = src.f_blocks;
+        dst.f_frsize = 4096;
+    }
+
+    [[nodiscard]]
+    size_t statfs_err_to_linux(ErrCode err) {
+        switch (err) {
+            case ErrCode::ENTRY_NOT_FOUND:      return -ENOENT;
+            case ErrCode::INVALID_CAPABILITY:   return -EBADF;
+            case ErrCode::TYPE_NOT_MATCHED:     return -EIO;
+            case ErrCode::INVALID_PARAM:        return -EINVAL;
+            case ErrCode::NULLPTR:              return -EFAULT;
+            case ErrCode::INSUFFICIENT_PERMISSIONS:
+                return -EACCES;
+            default:                            return -EIO;
+        }
+    }
+
+    [[nodiscard]]
+    size_t statfs_cap_to_user(CapIdx cap, void *buf) {
+        if (buf == nullptr) {
+            return -EFAULT;
+        }
+        if (cap == cap::null || cap == cap::error) {
+            return -EBADF;
+        }
+
+        VFSStatFS vfs_st{};
+        auto statfs_res = sys_vfs_statfs(cap, &vfs_st).to_result();
+        if (!statfs_res.has_value()) {
+            return statfs_err_to_linux(statfs_res.error());
+        }
+
+        linux_statfs st{};
+        fill_statfs_from_vfs(vfs_st, st);
+        memcpy(buf, &st, sizeof(st));
+        return 0;
     }
 
     [[nodiscard]]
@@ -1730,6 +1792,67 @@ size_t linux_sys_fstat(int fd, void *statbuf) {
     fill_kstat_from_attrs(attrs, kst);
     memcpy(statbuf, &kst, sizeof(kst));
     return 0;
+}
+
+size_t linux_sys_fstatfs(int fd, void *buf) {
+    CapIdx cap = fd_to_cap(fd);
+    if (cap == cap::error || cap == cap::null) {
+        return -EBADF;
+    }
+    return statfs_cap_to_user(cap, buf);
+}
+
+size_t linux_sys_statfs(const char *pathname, void *buf) {
+    if (buf == nullptr) {
+        return -EFAULT;
+    }
+    if (pathname == nullptr) {
+        return -EFAULT;
+    }
+    if (pathname[0] == '\0') {
+        return -ENOENT;
+    }
+
+    auto resolved = resolve_path_at(AT_FDCWD, pathname);
+    if (resolved.parent_cap == cap::null || resolved.parent_cap == cap::error ||
+        resolved.relative_path.empty())
+    {
+        return -ENOENT;
+    }
+
+    NodeMeta meta{};
+    auto node_type = stat_resolved_path(resolved, meta);
+    if (node_type == ResolvedNodeType::MISSING) {
+        return -ENOENT;
+    }
+    if (node_type == ResolvedNodeType::ERROR) {
+        return -EIO;
+    }
+
+    CapIdx cap = cap::error;
+    if (node_type == ResolvedNodeType::DIRECTORY) {
+        auto dir_res =
+            sys_vfs_opendir(resolved.parent_cap, resolved.relative_path.c_str(),
+                            flags::O_READ)
+                .to_result();
+        if (!dir_res.has_value()) {
+            return statfs_err_to_linux(dir_res.error());
+        }
+        cap = dir_res.value();
+    } else {
+        auto file_res =
+            sys_vfs_open(resolved.parent_cap, resolved.relative_path.c_str(),
+                         flags::O_READ)
+                .to_result();
+        if (!file_res.has_value()) {
+            return statfs_err_to_linux(file_res.error());
+        }
+        cap = file_res.value();
+    }
+
+    size_t ret = statfs_cap_to_user(cap, buf);
+    (void)sys_cap_remove(cap).to_result();
+    return ret;
 }
 
 size_t linux_sys_ftruncate(int fd, size_t length) {

--- a/module/linux-subsystem/file.h
+++ b/module/linux-subsystem/file.h
@@ -41,6 +41,8 @@ size_t linux_sys_renameat2(int olddirfd, const char *oldpath, int newdirfd,
                            const char *newpath, unsigned int flags);
 size_t linux_sys_getdents64(int fd, void *dirp, size_t count);
 size_t linux_sys_fstat(int fd, void *statbuf);
+size_t linux_sys_statfs(const char *pathname, void *buf);
+size_t linux_sys_fstatfs(int fd, void *buf);
 size_t linux_sys_fchmodat(int dirfd, const char *pathname, uint32_t mode);
 size_t linux_sys_fchownat(int dirfd, const char *pathname, uint32_t uid,
                           uint32_t gid, int flags);

--- a/module/linux-subsystem/main.cpp
+++ b/module/linux-subsystem/main.cpp
@@ -879,6 +879,12 @@ extern "C" size_t linux_dispatch(size_t a0, size_t a1, size_t a2, size_t a3,
         case __NR_fstat:
             return linux_sys_fstat(static_cast<int>(a0),
                                    reinterpret_cast<void *>(a1));
+        case __NR_statfs:
+            return linux_sys_statfs(reinterpret_cast<const char *>(a0),
+                                    reinterpret_cast<void *>(a1));
+        case __NR_fstatfs:
+            return linux_sys_fstatfs(static_cast<int>(a0),
+                                     reinterpret_cast<void *>(a1));
         case __NR_newfstatat:
             return linux_sys_newfstatat(
                 static_cast<int>(a0), reinterpret_cast<const char *>(a1),

--- a/module/test-linux/arch/loongarch64/entry.S
+++ b/module/test-linux/arch/loongarch64/entry.S
@@ -4,4 +4,10 @@
     .extern test_linux_main
 
 _start:
+    move $t0, $sp
+    ld.d $a0, $t0, 0
+    addi.d $a1, $t0, 8
+    slli.d $t2, $a0, 3
+    addi.d $t1, $a1, 8
+    add.d $a2, $t1, $t2
     b test_linux_main

--- a/module/test-linux/arch/riscv64/entry.S
+++ b/module/test-linux/arch/riscv64/entry.S
@@ -10,4 +10,11 @@ _start:
     auipc gp, %pcrel_hi(__global_pointer$)
     addi gp, gp, %pcrel_lo(1b)
     .option pop
+    mv t0, sp
+    ld a0, 0(t0)
+    addi a1, t0, 8
+    addi t1, a1, 8
+    slli t2, a0, 3
+    add t1, t1, t2
+    mv a2, t1
     j test_linux_main

--- a/module/test-linux/main.cpp
+++ b/module/test-linux/main.cpp
@@ -26,10 +26,17 @@ namespace {
     constexpr size_t __NR_read          = 63;
     constexpr size_t __NR_write         = 64;
     constexpr size_t __NR_pipe2         = 59;
+    constexpr size_t __NR_statfs        = 43;
+    constexpr size_t __NR_fstatfs       = 44;
     constexpr size_t __NR_clone         = 220;
     constexpr size_t __NR_wait4         = 260;
     constexpr size_t __NR_getcwd        = 17;
     constexpr size_t __NR_execve        = 221;
+    constexpr size_t __NR_exit_group    = 94;
+
+    constexpr long TMPFS_MAGIC          = 0x01021994;
+    constexpr long PROC_SUPER_MAGIC     = 0x9FA0;
+    constexpr long TARFS_SUPER_MAGIC    = 0x74617266;
 
     // open flags
     constexpr int O_RDONLY              = 0;
@@ -44,6 +51,59 @@ namespace {
     constexpr int SEEK_SET              = 0;
     constexpr int SEEK_CUR              = 1;
     constexpr int SEEK_END              = 2;
+
+    struct linux_fsid_t {
+        int val[2];
+    };
+
+    struct linux_statfs {
+        long f_type;
+        long f_bsize;
+        unsigned long f_blocks;
+        unsigned long f_bfree;
+        unsigned long f_bavail;
+        unsigned long f_files;
+        unsigned long f_ffree;
+        linux_fsid_t f_fsid;
+        long f_namelen;
+        long f_frsize;
+        long f_flags;
+        long f_spare[4];
+    };
+
+    void clear_statfs(linux_statfs &st) {
+        st.f_type   = 0;
+        st.f_bsize  = 0;
+        st.f_blocks = 0;
+        st.f_bfree  = 0;
+        st.f_bavail = 0;
+        st.f_files  = 0;
+        st.f_ffree  = 0;
+        st.f_fsid.val[0] = 0;
+        st.f_fsid.val[1] = 0;
+        st.f_namelen     = 0;
+        st.f_frsize      = 0;
+        st.f_flags       = 0;
+        for (int i = 0; i < 4; ++i) {
+            st.f_spare[i] = 0;
+        }
+    }
+
+    bool statfs_unsupported_zero(const linux_statfs &st) {
+        if (st.f_bfree != 0 || st.f_bavail != 0 || st.f_files != 0 ||
+            st.f_ffree != 0 || st.f_fsid.val[0] != 0 ||
+            st.f_fsid.val[1] != 0 || st.f_namelen != 0 ||
+            st.f_flags != 0)
+        {
+            return false;
+        }
+        for (int i = 0; i < 4; ++i) {
+            if (st.f_spare[i] != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     size_t strlen(const char *s) {
         size_t len = 0;
@@ -92,6 +152,20 @@ namespace {
         puts(detail);
         puts("\n");
         g_tests_failed++;
+    }
+
+    [[noreturn]]
+    void finish_tests() {
+        puts("\n=== TEST SUMMARY ===\n");
+        if (g_tests_failed == 0) {
+            puts("ALL TESTS PASSED\n");
+        } else {
+            puts("SOME TESTS FAILED\n");
+        }
+        linux_syscall(static_cast<size_t>(g_tests_failed == 0 ? 0 : 1),
+                      0, 0, 0, 0, 0, __NR_exit_group);
+        while (true) {
+        }
     }
 }  // namespace
 
@@ -165,6 +239,79 @@ static long linux_fchownat(int dirfd, const char *path, unsigned uid,
                          static_cast<size_t>(gid),
                          static_cast<size_t>(flags),
                          0, __NR_fchownat);
+}
+
+static long linux_statfs_sys(const char *path, linux_statfs *buf) {
+    return linux_syscall(reinterpret_cast<size_t>(path),
+                         reinterpret_cast<size_t>(buf),
+                         0, 0, 0, 0, __NR_statfs);
+}
+
+static long linux_fstatfs_sys(int fd, linux_statfs *buf) {
+    return linux_syscall(static_cast<size_t>(fd),
+                         reinterpret_cast<size_t>(buf),
+                         0, 0, 0, 0, __NR_fstatfs);
+}
+
+static void test_statfs_basic(int tar_fd) {
+    puts("Test 8.75: statfs/fstatfs filesystem types...\n");
+
+    linux_statfs st;
+    clear_statfs(st);
+    long root_ret = linux_statfs_sys("/", &st);
+    if (root_ret == 0 && st.f_type == TMPFS_MAGIC && st.f_blocks != 0 &&
+        st.f_bsize == 4096 && st.f_frsize == 4096)
+    {
+        test_pass("statfs tmpfs root");
+    } else {
+        test_fail("statfs tmpfs root", "unexpected root fs data");
+    }
+    if (root_ret == 0 && statfs_unsupported_zero(st)) {
+        test_pass("statfs unsupported fields zero");
+    } else {
+        test_fail("statfs unsupported fields zero", "expected zero fields");
+    }
+
+    clear_statfs(st);
+    long proc_ret = linux_statfs_sys("/proc", &st);
+    if (proc_ret == 0 && st.f_type == PROC_SUPER_MAGIC && st.f_blocks != 0) {
+        test_pass("statfs procfs");
+    } else {
+        test_fail("statfs procfs", "unexpected procfs data");
+    }
+
+    clear_statfs(st);
+    long initrd_ret = linux_statfs_sys("/initrd", &st);
+    if (initrd_ret == 0 && st.f_type == TARFS_SUPER_MAGIC &&
+        st.f_blocks == 0)
+    {
+        test_pass("statfs tarfs");
+    } else {
+        test_fail("statfs tarfs", "unexpected tarfs data");
+    }
+
+    clear_statfs(st);
+    long fd_ret = linux_fstatfs_sys(tar_fd, &st);
+    if (fd_ret == 0 && st.f_type == TARFS_SUPER_MAGIC) {
+        test_pass("fstatfs opened file");
+    } else {
+        test_fail("fstatfs opened file", "unexpected fstatfs type");
+    }
+
+    clear_statfs(st);
+    long missing_ret = linux_statfs_sys("/missing-statfs-path", &st);
+    if (missing_ret == -2) {
+        test_pass("statfs missing path");
+    } else {
+        test_fail("statfs missing path", "expected -ENOENT");
+    }
+
+    long bad_fd_ret = linux_fstatfs_sys(999, &st);
+    if (bad_fd_ret == -9) {
+        test_pass("fstatfs invalid fd");
+    } else {
+        test_fail("fstatfs invalid fd", "expected -EBADF");
+    }
 }
 
 static void test_pipe_basic() {
@@ -260,7 +407,7 @@ static void test_pipe_fork() {
         linux_close(fds[0]);
         (void)linux_write_sys(fds[1], "child", 5);
         linux_close(fds[1]);
-        linux_syscall(0, 0, 0, 0, 0, 0, 94);
+        linux_syscall(0, 0, 0, 0, 0, 0, __NR_exit_group);
         while (true) {
         }
     }
@@ -333,15 +480,7 @@ extern "C" [[noreturn]] void test_linux_main(size_t argc, const char *argv[],
         } else {
             test_fail("execve argv/envp", "unexpected startup arguments");
         }
-
-        puts("\n=== TEST SUMMARY ===\n");
-        if (g_tests_failed == 0) {
-            puts("ALL TESTS PASSED\n");
-        } else {
-            puts("SOME TESTS FAILED\n");
-        }
-        while (true) {
-        }
+        finish_tests();
     }
 
     // Original test: write hello three times
@@ -372,6 +511,7 @@ extern "C" [[noreturn]] void test_linux_main(size_t argc, const char *argv[],
                                O_RDONLY, 0));
     if (fd >= 3) {
         test_pass("open existing file");
+        test_statfs_basic(fd);
     } else {
         test_fail("open existing file", "expected fd >= 3");
     }
@@ -510,15 +650,5 @@ extern "C" [[noreturn]] void test_linux_main(size_t argc, const char *argv[],
     } else {
         test_fail("execve self", "execve unexpectedly returned success");
     }
-
-    // Summary
-    puts("\n=== TEST SUMMARY ===\n");
-    if (g_tests_failed == 0) {
-        puts("ALL TESTS PASSED\n");
-    } else {
-        puts("SOME TESTS FAILED\n");
-    }
-
-    while (true) {
-    }
+    finish_tests();
 }


### PR DESCRIPTION
* 给 linuxss 添加 __NR_statfs 和 __NR_fstatfs 系统调用
* 修复了 test-linux 入口点的 argc/argv/envp 问题
* 优化 test-linux 的退出逻辑